### PR TITLE
updated font-sizes to work around block-inline

### DIFF
--- a/scss/jquery.gridder.scss
+++ b/scss/jquery.gridder.scss
@@ -5,6 +5,12 @@
     margin: 0px;
     padding: 0px;
     list-style-type: none;
+    font-size:0;
+}
+
+.gridder-list, .gridder-show
+{
+    font-size:16px;
 }
 
 .gridder-list { 


### PR DESCRIPTION
I updated the font-size of the parent element to 0 and added standard 16px to both the gridder-list and gridder-show element.